### PR TITLE
Link rc.openvpnserver to /etc/rc.d/

### DIFF
--- a/openvpn_server_x64.plg
+++ b/openvpn_server_x64.plg
@@ -96,6 +96,7 @@ chmod 0770 &emhttp;/event/*
 chmod 0770 &emhttp;/scripts/*
 
 cp -nr &emhttp;/&name; /boot/config/plugins
+ln -s /usr/local/emhttp/plugins/openvpnserver/scripts/rc.openvpnserver /etc/rc.d/
 </INLINE>
 </FILE>
 


### PR DESCRIPTION
Hi Peter, 

I created a link to rc.d script in /etc/rc.d in the install script. I tested it works when unraid is restarted.

Best Alex