### PR TITLE
Update openvpnserversettings.page

### DIFF
--- a/openvpnserversettings.page
+++ b/openvpnserversettings.page
@@ -29,7 +29,7 @@ $CHECKFOLDERVPN = trim($CHECKFOLDERVPNTMP);
 	
 <?if ($CHECKFOLDERVPN == "Yes"):?>
      
-  <?if (($openvpnserver_running == "yes") && ($pids=="0")):?>
+  <?if (($openvpnserver_running == "yes") && ($pids!="0")):?>
     <div><left><b>To change configuration - Press Stop in "Control Action"</b></center></div>
   <?endif;?>
 	


### PR DESCRIPTION
The message informing users to stop the server in order to make config changes is not shown while the server is running. They just get an empty page.